### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,5 +1,8 @@
 name: Lint and Test Charts
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/nunoferna/pihole-helm/security/code-scanning/2](https://github.com/nunoferna/pihole-helm/security/code-scanning/2)

In general, the fix is to declare an explicit `permissions` block that restricts the GITHUB_TOKEN to the least privileges needed. Since this workflow only checks out code and runs lint/test tooling, it should only require read access to repository contents. Adding `permissions: contents: read` at the workflow root ensures all jobs inherit restricted permissions and addresses the CodeQL finding.

The best fix here is to add a top-level `permissions` block right after the `name:` (or before/after `on:`) in `.github/workflows/lint-test.yaml`. This way, the single job `lint-test` will inherit these restricted permissions without any change to functionality. No additional imports or methods are needed; this is a pure YAML configuration change.

Concretely, in `.github/workflows/lint-test.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Lint and Test Charts` and the `on:` block (around line 2–3). No other parts of the workflow need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
