### PR TITLE
feat: add securityContext deployment

### DIFF
--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -48,7 +48,9 @@ helm install pihole nunoferna/pihole \
 | metrics.enabled | boolean | `false` | Whether to enable the Pi-hole metrics exporter. Provides Prometheus metrics on port 9617. Required for any metrics-related features (ServiceMonitor, Grafana dashboards, etc.). |
 | metrics.env | array | `[{"name":"INTERVAL","value":"10s"}]` | Additional environment variables for the metrics exporter. PIHOLE_HOSTNAME, PIHOLE_PORT, and PIHOLE_PROTOCOL are auto-generated from the number of replicas (headless DNS for StatefulSet, ClusterIP FQDN for Deployment). Use this to pass PIHOLE_PASSWORD, INTERVAL, or other custom variables. |
 | metrics.image.repository | string | `"ekofr/pihole-exporter"` | Container image for the Pi-hole metrics exporter. |
+| metrics.podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls where compatible. |
 | metrics.port | integer | `9617` | Port on which the metrics exporter will listen. |
+| metrics.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls. |
 | metrics.serviceMonitor.enabled | boolean | `false` | Whether to create a ServiceMonitor resource for Prometheus Operator integration. |
 
 ### K8S Services
@@ -342,12 +344,16 @@ helm install pihole nunoferna/pihole \
 | podAnnotations | object | `{}` |  |
 | podDisruptionBudget.enabled | bool | `false` |  |
 | podDisruptionBudget.minAvailable | int | `1` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | replicas | int | `1` |  |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.add | list | `[]` |  |
+| securityContext.capabilities.drop | list | `[]` |  |
+| securityContext.readOnlyRootFilesystem | bool | `false` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `"pihole"` |  |

--- a/charts/pihole/templates/deployment-metrics.yaml
+++ b/charts/pihole/templates/deployment-metrics.yaml
@@ -39,6 +39,10 @@ spec:
         {{- toYaml . | nindent 8 }}
   {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "pihole.fullname" .) | quote }}
+  {{- with .Values.metrics.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
       containers:
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -49,6 +53,10 @@ spec:
   {{- end }}
   {{- with .Values.metrics.args }}
           args:
+            {{- toYaml . | nindent 12 }}
+  {{- end }}
+  {{- with .Values.metrics.securityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
   {{- end }}
           env:

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
 {{- else }}
       dnsPolicy: ClusterFirst
 {{- end }}
+{{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -61,16 +65,33 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
 {{- end }}
+{{- $securityContext := .Values.securityContext | default dict }}
+{{- $capabilities := $securityContext.capabilities | default dict }}
+{{- $capAdd := $capabilities.add | default (list) }}
+{{- $capDrop := $capabilities.drop | default (list) }}
+{{- $hasDynamicCaps := or .Values.pihole.ftl.dhcp.service.enabled .Values.networking.hostNetwork }}
+{{- $hasCaps := or $hasDynamicCaps (gt (len $capAdd) 0) (gt (len $capDrop) 0) }}
+{{- if or (omit $securityContext "capabilities") $hasCaps }}
           securityContext:
+  {{- with (omit $securityContext "capabilities") }}
+            {{- toYaml . | nindent 12 }}
+  {{- end }}
+  {{- if $hasCaps }}
             capabilities:
+    {{- with $capDrop }}
+              drop:
+                {{- toYaml . | nindent 16 }}
+    {{- end }}
+    {{- if or $hasDynamicCaps (gt (len $capAdd) 0) }}
               add:
-{{- if or .Values.pihole.ftl.dhcp.service.enabled .Values.networking.hostNetwork }}
+      {{- if or .Values.pihole.ftl.dhcp.service.enabled .Values.networking.hostNetwork }}
                 - NET_ADMIN # Required for DHCP & modifying routing tables
                 - NET_RAW   # Required for DHCPv6 & collision checks
-{{- end }}
-{{- with .Values.securityContext.capabilities.add }}
-  {{- range . }}
+      {{- end }}
+      {{- range $capAdd }}
                 - {{ . }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}
           lifecycle:

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -114,6 +114,26 @@
                         }
                     }
                 },
+                "podSecurityContext": {
+                    "description": "Pod security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls where compatible.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "port": {
                     "description": "Port on which the metrics exporter will listen.",
                     "type": [
@@ -142,6 +162,43 @@
                                     "type": "string"
                                 },
                                 "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securityContext": {
+                    "description": "Container security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
                                     "type": "string"
                                 }
                             }
@@ -1714,6 +1771,19 @@
                 }
             }
         },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "replicas": {
             "type": "integer"
         },
@@ -1747,13 +1817,22 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
                 "capabilities": {
                     "type": "object",
                     "properties": {
                         "add": {
                             "type": "array"
+                        },
+                        "drop": {
+                            "type": "array"
                         }
                     }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
                 }
             }
         },

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -1035,6 +1035,25 @@ metrics:
   command: []
   # Override metrics container args (optional)
   args: []
+  # @schema type:object,null
+  # -- (object) Pod security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls where compatible.
+  # @section -- Metrics
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  # @schema type:object,null
+  # -- (object) Container security context for the metrics exporter. Defaults follow Pod Security Standards Restricted controls.
+  # @section -- Metrics
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     limits:
       memory: 64Mi
@@ -1064,9 +1083,16 @@ metrics:
     labelValue: "1"
     annotations: {}
 
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
+    drop: []
     add: []
+  readOnlyRootFilesystem: false
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
This pull request enhances the security configuration for both the main Pi-hole deployment and the metrics exporter in the Helm chart. It introduces explicit, standards-aligned pod and container security context options, making it easier to comply with Kubernetes Pod Security Standards and to customize security settings for different workloads.

**Security context improvements:**

* Added `podSecurityContext` and `securityContext` fields for the metrics exporter, with secure defaults (e.g., `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and dropping all capabilities). These are now configurable via `values.yaml` and documented in `README.md`. [[1]](diffhunk://#diff-74c171d443ba82ea3b11a6f0d7f77e42d4b01bc2768c3ef9dbe3694acc4a064dR1038-R1056) [[2]](diffhunk://#diff-9741f7530bc51521a33e7b56d939808e77d2c1c305f9a4113ce9431296e00915R51-R53) [[3]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R117-R136) [[4]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R171-R207)
* Added `podSecurityContext` and enhanced `securityContext` options for the main Pi-hole deployment, including support for `seccompProfile`, `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, and both `add` and `drop` capabilities lists. [[1]](diffhunk://#diff-74c171d443ba82ea3b11a6f0d7f77e42d4b01bc2768c3ef9dbe3694acc4a064dR1086-R1095) [[2]](diffhunk://#diff-9741f7530bc51521a33e7b56d939808e77d2c1c305f9a4113ce9431296e00915R347-R356) [[3]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R1774-R1786) [[4]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R1820-R1835)

**Template and schema updates:**

* Updated `deployment.yaml` and `deployment-metrics.yaml` templates to apply the new security context fields to both pods and containers, ensuring the rendered manifests reflect user configuration. [[1]](diffhunk://#diff-30e0453700126a81330cdd1bf42c61938bbdbfb1f157121c4caf475a10d654e4R42-R45) [[2]](diffhunk://#diff-30e0453700126a81330cdd1bf42c61938bbdbfb1f157121c4caf475a10d654e4R68-R95) [[3]](diffhunk://#diff-d97c6df55b47200446a4c19fd3cfaeb071748a25da960e6e6bda7d5066579247R42-R45) [[4]](diffhunk://#diff-d97c6df55b47200446a4c19fd3cfaeb071748a25da960e6e6bda7d5066579247R57-R60)
* Extended the JSON schema (`values.schema.json`) to validate the new security-related fields for both the main deployment and the metrics exporter. [[1]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R117-R136) [[2]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R171-R207) [[3]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R1774-R1786) [[4]](diffhunk://#diff-43d87662e181eed765c5f3f1db790f6204603f8e2c74287e91c64020ad3509b8R1820-R1835)

**Documentation updates:**

* Documented all new and updated security context fields in the `README.md`, including descriptions and default values for each option. [[1]](diffhunk://#diff-9741f7530bc51521a33e7b56d939808e77d2c1c305f9a4113ce9431296e00915R51-R53) [[2]](diffhunk://#diff-9741f7530bc51521a33e7b56d939808e77d2c1c305f9a4113ce9431296e00915R347-R356)

These changes make it much easier to run Pi-hole in hardened Kubernetes environments and to meet security compliance requirements.